### PR TITLE
Remove Common.Logging dependency and implement 'ReturnJob' (release from container)

### DIFF
--- a/Source/Ninject.Extensions.Quartz/Ninject.Extensions.Quartz.csproj
+++ b/Source/Ninject.Extensions.Quartz/Ninject.Extensions.Quartz.csproj
@@ -65,18 +65,6 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL" Condition="$(TargetFrameworkVersion) == 'v4.5'">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
-    </Reference>
-    <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL" Condition="$(TargetFrameworkVersion) == 'v4.0'">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
-    </Reference>
-    <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL" Condition="$(TargetFrameworkVersion) == 'v3.5'">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Common.Logging.2.1.2\lib\net35\Common.Logging.dll</HintPath>
-    </Reference>
     <Reference Include="Ninject, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL" Condition="$(TargetFrameworkVersion) == 'v4.5'">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Ninject.3.0.1.10\lib\net45-full\Ninject.dll</HintPath>

--- a/Source/Ninject.Extensions.Quartz/NinjectJobFactory.cs
+++ b/Source/Ninject.Extensions.Quartz/NinjectJobFactory.cs
@@ -59,7 +59,7 @@ namespace Ninject.Extensions.Quartz
 		/// </summary>
 		public void ReturnJob(IJob job)
 		{
-			
+		    _kernel.Release(job);
 		}
 	}
 }

--- a/Source/Ninject.Extensions.Quartz/NinjectJobFactory.cs
+++ b/Source/Ninject.Extensions.Quartz/NinjectJobFactory.cs
@@ -5,7 +5,6 @@
 // Licensed under the MIT license.
 using System;
 using System.Globalization;
-using Common.Logging;
 using Quartz;
 using Quartz.Spi;
 
@@ -14,8 +13,6 @@ namespace Ninject.Extensions.Quartz
 	public class NinjectJobFactory : IJobFactory
 	{
 		private readonly IKernel _kernel;
-
-		private static readonly ILog log = LogManager.GetLogger(typeof(NinjectJobFactory));
 
 		public NinjectJobFactory(IKernel kernel)
 		{
@@ -47,11 +44,6 @@ namespace Ninject.Extensions.Quartz
 			Type jobType = jobDetail.JobType;
 			try
 			{
-				if (log.IsDebugEnabled)
-				{
-					log.Debug(string.Format(CultureInfo.InvariantCulture, "Producing instance of Job '{0}', class={1}", jobDetail.Key, jobType.FullName));
-				}
-
 				return _kernel.Get(jobType) as IJob;
 			}
 			catch (Exception e)


### PR DESCRIPTION
Quartz 2.3.1 upgraded to Common.Logging 3, which breaks all libraries depending on both Quartz and Common.Logging.

Because there was literally only one place where logging was used (and it was only a debug log as well), I completely removed all references to Common.Logging, to avoid this issue in the future.

Implemented ReturnJob (kernel.Release(..)) for bonus points.